### PR TITLE
[feat] add support for Yarn + inheriting exec process

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -8,6 +8,14 @@ const devDependencies = require('./devDependencies.json');
 
 const deleteFile = (fileName) => fs.unlinkSync(path.join(process.cwd(), fileName));
 const writeFile = (fileName, data) => fs.writeFileSync(path.join(process.cwd(), fileName), data);
+const isYarnAvailable = () => {
+  try {
+    execSync('yarnpkg --version', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 console.log('🔄 Please wait...');
 
@@ -15,7 +23,11 @@ packageJson.scripts.start = `${packageJson.scripts.start} --config ../../../../r
 packageJson.jest = Object.assign(packageJson.jest, jestJson);
 writeFile('package.json', JSON.stringify(packageJson, null, 2));
 
-execSync(`npm i ${devDependencies.join(' ')} --save-dev --save-exact`);
+if (isYarnAvailable) {
+  execSync(`yarn add ${devDependencies.join(' ')} --dev --exact`);
+} else {
+  execSync(`npm i ${devDependencies.join(' ')} --save-dev --save-exact`);
+}
 
 deleteFile('App.js');
 deleteFile('__tests__/App.js');
@@ -26,4 +38,4 @@ deleteFile('README.md');
 deleteFile('LICENSE');
 deleteFile('setup.js');
 
-console.log('✅ Setup completed! You can now start with: npm start');
+console.log(`✅ Setup completed! You can now start with: ${isYarnAvailable ? "yarn" : "npm"} start`);

--- a/setup.js
+++ b/setup.js
@@ -17,19 +17,23 @@ const isYarnAvailable = () => {
   }
 }
 
-console.log('🔄 Please wait...');
+console.log('\n🔄 Please wait...\n');
 
 packageJson.scripts.start = `${packageJson.scripts.start} --config ../../../../rn-cli.config.js`;
 packageJson.jest = Object.assign(packageJson.jest, jestJson);
 writeFile('package.json', JSON.stringify(packageJson, null, 2));
 
-const logInstallingWith = pkg => console.log(`📦 Installing dependencies with ${pkg}...`);
+const logInstallingWith = pkg => console.log(`\n📦 Installing dependencies with ${pkg}...\n`);
+const execOptions = {
+  stdio: 'inherit'
+}
+
 if (isYarnAvailable) {
   logInstallingWith("yarn");
-  execSync(`yarn add ${devDependencies.join(' ')} --dev --exact`);
+  execSync(`yarn add ${devDependencies.join(' ')} --dev --exact`, execOptions);
 } else {
   logInstallingWith("npm");
-  execSync(`npm i ${devDependencies.join(' ')} --save-dev --save-exact`);
+  execSync(`npm i ${devDependencies.join(' ')} --save-dev --save-exact`, execOptions);
 }
 
 deleteFile('App.js');
@@ -41,4 +45,4 @@ deleteFile('README.md');
 deleteFile('LICENSE');
 deleteFile('setup.js');
 
-console.log(`✅ Setup completed! You can now start with: ${isYarnAvailable ? "yarn" : "npm"} start`);
+console.log(`\n✅ Setup completed! You can now start with: ${isYarnAvailable ? "yarn" : "npm"} start\n`);

--- a/setup.js
+++ b/setup.js
@@ -23,9 +23,12 @@ packageJson.scripts.start = `${packageJson.scripts.start} --config ../../../../r
 packageJson.jest = Object.assign(packageJson.jest, jestJson);
 writeFile('package.json', JSON.stringify(packageJson, null, 2));
 
+const logInstallingWith = pkg => console.log(`📦 Installing dependencies with ${pkg}...`);
 if (isYarnAvailable) {
+  logInstallingWith("yarn");
   execSync(`yarn add ${devDependencies.join(' ')} --dev --exact`);
 } else {
+  logInstallingWith("npm");
   execSync(`npm i ${devDependencies.join(' ')} --save-dev --save-exact`);
 }
 

--- a/setup.js
+++ b/setup.js
@@ -16,6 +16,11 @@ const isYarnAvailable = () => {
     return false;
   }
 }
+const currPackager = isYarnAvailable ? "yarn" : "npm";
+const logInstallingWith = pkg => console.log(`\n📦 Installing dependencies with ${pkg}...\n`);
+const execOptions = {
+  stdio: 'inherit'
+}
 
 console.log('\n🔄 Please wait...\n');
 
@@ -23,16 +28,11 @@ packageJson.scripts.start = `${packageJson.scripts.start} --config ../../../../r
 packageJson.jest = Object.assign(packageJson.jest, jestJson);
 writeFile('package.json', JSON.stringify(packageJson, null, 2));
 
-const logInstallingWith = pkg => console.log(`\n📦 Installing dependencies with ${pkg}...\n`);
-const execOptions = {
-  stdio: 'inherit'
-}
+logInstallingWith(currPackager);
 
 if (isYarnAvailable) {
-  logInstallingWith("yarn");
   execSync(`yarn add ${devDependencies.join(' ')} --dev --exact`, execOptions);
 } else {
-  logInstallingWith("npm");
   execSync(`npm i ${devDependencies.join(' ')} --save-dev --save-exact`, execOptions);
 }
 
@@ -45,4 +45,4 @@ deleteFile('README.md');
 deleteFile('LICENSE');
 deleteFile('setup.js');
 
-console.log(`\n✅ Setup completed! You can now start with: ${isYarnAvailable ? "yarn" : "npm"} start\n`);
+console.log(`\n✅ Setup completed! You can now start with: ${currPackager} start\n`);


### PR DESCRIPTION
hello there 👋,

really cool template @emin93, easy to follow + simple and efficient idea!

while using it during this week, I found myself tweaking `setup.js` before running `node setup.js` to use `yarn`,

in this PR, I'm adding support for `yarn` and also inheriting the parent process in `execSync`, so you can see the `stdio` from `yarn add` or `npm i` in the process (not only warnings/errors)

like:

<img width="1087" alt="screen shot 2018-03-28 at 7 52 18 pm" src="https://user-images.githubusercontent.com/829902/38013657-6687908e-32c2-11e8-89ac-90bcf78b1f5a.png">
<img width="1087" alt="screen shot 2018-03-28 at 7 52 21 pm" src="https://user-images.githubusercontent.com/829902/38013664-6aa60934-32c2-11e8-8912-8d3023cb9da1.png">

thanks! 🤗