### PR TITLE
Enable esModuleInterop

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,7 @@
  * https://github.com/emin93/react-native-template-typescript
  */
 
-import * as React from 'react';
+import React from 'react';
 import {
   Platform,
   StyleSheet,

--- a/__tests__/App.tsx
+++ b/__tests__/App.tsx
@@ -1,5 +1,5 @@
 import 'react-native';
-import * as React from 'react';
+import React from 'react';
 import App from '../App';
 
 // Note: test renderer must be required after react-native.

--- a/__tests__/App.tsx
+++ b/__tests__/App.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import App from '../App';
 
 // Note: test renderer must be required after react-native.
-import * as renderer from 'react-test-renderer';
+import renderer from 'react-test-renderer';
 
 it('renders correctly', () => {
   const tree = renderer.create(

--- a/devDependencies.json
+++ b/devDependencies.json
@@ -1,9 +1,9 @@
 [
-    "typescript",
-    "react-native-typescript-transformer",
-    "ts-jest",
+    "@types/jest",
     "@types/react",
     "@types/react-native",
-    "@types/jest",
-    "@types/react-test-renderer"
+    "@types/react-test-renderer",
+    "react-native-typescript-transformer",
+    "ts-jest",
+    "typescript"
 ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
         "jsx": "react",
         "noEmit": true,
         "moduleResolution": "node",
-        "noImplicitAny": true
+        "noImplicitAny": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
New features in tsconfig allow us to stay closer to the default react-native template.

Specifically,

"allowSyntheticDefaultImports": true, 
"esModuleInterop": true

allow us to import the same as react-native default template.

```
import React from 'react';
```
