### PR TITLE
Add babel.config.js to TypeScript excludes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "strict": true,
     "target": "esnext"
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "babel.config.js"]
 }


### PR DESCRIPTION
On a newly created project, after running setup.js, `npm run tsc` fails with the error: `babel.config.js:1:1 - error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided`. This patch adds babel.config.js to the exclude setting in tsconfig.json.