### PR TITLE
Add metro.config.js to tsconfig excluded files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "strict": true,
     "target": "esnext"
   },
-  "exclude": ["node_modules", "babel.config.js"]
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
 }


### PR DESCRIPTION
In the latest RC of React Native (0.59.0-rc.3) a `metro.config.js` file is created with the following content:

```js
/**
 * Metro configuration for React Native
 * https://github.com/facebook/react-native
 *
 * @format
 */

module.exports = {
  transformer: {
    getTransformOptions: async () => ({
      transform: {
        experimentalImportSupport: false,
        inlineRequires: false,
      },
    }),
  },
};
```

When you run `tsc`, it fails with this error:

```
metro.config.js:8:1 - error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.

8 module.exports = {
  ~~~~~~


Found 1 error.
```

This PR fixes that error by excluding the `metro.config.js` file just like we did for `babel.config.js`.